### PR TITLE
Fix docker run command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ docker build -t activation-service:my-tag .
 Make a copy of the configuration file `config/as.yml` and modify according to your environment. 
 Then run the image:
 ```shell
-docker run --rm -it -p 7000:7000 -v <PATH_TO_FILE>/as.yml:/home/portal/config/as.yml activation-service:my-tag
+docker run --rm -it -p 7000:7000 -v <PATH_TO_FILE>/as.yml:/home/aservice/config/as.yml activation-service:my-tag
 ```
 
 ### Kubernetes


### PR DESCRIPTION
Fixes docker run command from readme: volume path is wrong.

Sorry for issue with previous PR !

Edit: It looks like I'm not allowed to add a label